### PR TITLE
fix: Remove deprecated Terraform syntax

### DIFF
--- a/src/introspection.mixin.tf
+++ b/src/introspection.mixin.tf
@@ -3,7 +3,7 @@ locals {
   # tflint-ignore: terraform_unused_declarations
   check_required_tags = module.this.enabled ? [
     for k in var.required_tags :
-    lookup(module.this.tags, k)
+    module.this.tags[k]
   ] : []
 }
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -24,7 +24,7 @@ module "snowflake_label" {
   source  = "cloudposse/label/null"
   version = "0.25.0"
 
-  environment      = lookup(module.utils.region_az_alt_code_maps["to_short"], local.snowflake_account_region)
+  environment      = module.utils.region_az_alt_code_maps["to_short"][local.snowflake_account_region]
   delimiter        = "_"
   label_value_case = "upper"
 


### PR DESCRIPTION
## Why

Deprecated HCL syntax triggers linting warnings and will eventually be removed in future Terraform versions. Cleaning these up improves code quality, maintainability, and ensures forward compatibility.

## What

Automated fixes applied via `tflint --fix` with the following rules enabled:

| Rule | Description | Example |
|------|-------------|---------|
| `terraform_deprecated_interpolation` | Remove unnecessary interpolation wrappers | `"${var.foo}"` → `var.foo` |
| `terraform_deprecated_index` | Replace legacy dot-index syntax | `list.0` → `list[0]` |
| `terraform_deprecated_lookup` | Replace deprecated `lookup()` calls | `lookup(map, key)` → `map[key]` |

## References

- [tflint terraform_deprecated_interpolation](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_interpolation.md)
- [tflint terraform_deprecated_index](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_index.md)
- [tflint terraform_deprecated_lookup](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_lookup.md)
- [Terraform: References to Named Values](https://developer.hashicorp.com/terraform/language/expressions/references)